### PR TITLE
Testing and CI Changes

### DIFF
--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -1,0 +1,22 @@
+name: Build Wheels + Publish to PyPi
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python to Build Wheel
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install Poetry
+        run: pip install poetry
+          poetry install
+      - name: Build wheels
+        env:
+          APIKEY: ${{ secrets.PYPI_TOKEN }}
+        run: poetry build --username='__token__' --password='$APIKEY' --dry-run

--- a/.github/workflows/run_coverage.yaml
+++ b/.github/workflows/run_coverage.yaml
@@ -42,6 +42,6 @@ jobs:
       - name: Pytest
         run: |
           poetry run pytest --cov=dispike tests/
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v1.1.1
         with:
           fail_ci_if_error: true

--- a/.github/workflows/run_coverage.yaml
+++ b/.github/workflows/run_coverage.yaml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Test Dispike
+name: Run Code Coverage for Dispike
 
 on:
   push:

--- a/.github/workflows/test_python_library.yaml
+++ b/.github/workflows/test_python_library.yaml
@@ -35,6 +35,7 @@ jobs:
           pip install poetry
           poetry install
       - name: Lint with pylint
+        if: ${{ matrix.python-version }} != 3.9 # Python 3.9 Pylint issue https://github.com/PyCQA/pylint/issues/3882
         run: |
           # stop the build if there are Python syntax errors or undefined names
           # Bug with pylint and pydantic

--- a/.github/workflows/test_python_library.yaml
+++ b/.github/workflows/test_python_library.yaml
@@ -19,15 +19,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up Python 3.7
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python-version }}
       - name: Install Poetry
         run: |
           pip install poetry

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # dispike
 
 ***
+[![codecov](https://codecov.io/gh/ms7m/dispike/branch/master/graph/badge.svg?token=E5AXLZDP9O)](https://codecov.io/gh/ms7m/dispike) ![Test Dispike](https://github.com/ms7m/dispike/workflows/Test%20Dispike/badge.svg?branch=master) ![PyPi Link](https://img.shields.io/badge/Available%20on%20PyPi-Dispike-blue?logo=pypi&link=%22https://pypi.org/project/dispike%22)
+
+***
+
+
+
 an *extremely-extremely* early WIP library for easily creating REST-based webhook bots for discord using the new Slash Commands feature. 
 
 Powered by FastAPI.
@@ -152,3 +158,11 @@ When configuring your endpoint on discord settings, be sure to append ``/interac
   - [Edit Followup Message](https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message)
   - [Delete Followup Message](https://discord.com/developers/docs/interactions/slash-commands#delete-followup-message)
 - Handling followup messages.
+
+
+
+# Development
+
+Help is wanted in mantaining this library. Please try to direct PRs to the ``dev`` branch, and use black formatting (if possible).
+
+![Test Dispike](https://github.com/ms7m/dispike/workflows/Test%20Dispike/badge.svg?branch=dev)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,15 @@
 [[package]]
+name = "aiocontextvars"
+version = "0.2.2"
+description = "Asyncio support for PEP-567 contextvars backport."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+contextvars = {version = "2.4", markers = "python_version < \"3.7\""}
+
+[[package]]
 name = "appdirs"
 version = "1.4.4"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -53,6 +64,7 @@ python-versions = ">=3.6"
 [package.dependencies]
 appdirs = "*"
 click = ">=7.1.2"
+dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.6,<1"
 regex = ">=2020.1.8"
@@ -108,6 +120,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "contextvars"
+version = "2.4"
+description = "PEP 567 Backport"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+immutables = ">=0.9"
+
+[[package]]
 name = "coverage"
 version = "5.3.1"
 description = "Code coverage measurement for Python"
@@ -117,6 +140,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
 toml = ["toml"]
+
+[[package]]
+name = "dataclasses"
+version = "0.8"
+description = "A backport of the dataclasses module for Python 3.6"
+category = "main"
+optional = false
+python-versions = ">=3.6, <3.7"
 
 [[package]]
 name = "fastapi"
@@ -186,6 +217,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "immutables"
+version = "0.14"
+description = "Immutable Collections"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "importlib-metadata"
 version = "3.3.0"
 description = "Read metadata from Python packages"
@@ -239,6 +278,7 @@ optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
+aiocontextvars = {version = ">=0.2.0", markers = "python_version < \"3.7\""}
 colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
 win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
 
@@ -353,6 +393,9 @@ category = "main"
 optional = false
 python-versions = ">=3.6"
 
+[package.dependencies]
+dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
+
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
@@ -457,21 +500,6 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
-name = "pytest-httpx"
-version = "0.10.1"
-description = "Send responses to httpx."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-httpx = ">=0.16.0,<0.17.0"
-pytest = ">=6.0.0,<7.0.0"
-
-[package.extras]
-testing = ["pytest-asyncio (>=0.14.0,<0.15.0)", "pytest-cov (>=2.0.0,<3.0.0)"]
-
-[[package]]
 name = "regex"
 version = "2020.11.13"
 description = "Alternative regular expression module, to replace re."
@@ -496,6 +524,17 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+
+[[package]]
+name = "respx"
+version = "0.16.3"
+description = "A utility for mocking out the Python HTTPX and HTTP Core libraries."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+httpx = ">=0.15"
 
 [[package]]
 name = "rfc3986"
@@ -526,6 +565,9 @@ description = "Sniff out which async library your code is running under"
 category = "main"
 optional = false
 python-versions = ">=3.5"
+
+[package.dependencies]
+contextvars = {version = ">=2.1", markers = "python_version < \"3.7\""}
 
 [[package]]
 name = "starlette"
@@ -637,10 +679,14 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7"
-content-hash = "47994ec0ebbf1e73fb7488b6eda5c66f85a21562e12f92427de46ba7ea519194"
+python-versions = "^3.6"
+content-hash = "4699f868705e42dca9e2289e54aed7fb74016467cc7fdbf46f279b334bdf57e9"
 
 [metadata.files]
+aiocontextvars = [
+    {file = "aiocontextvars-0.2.2-py2.py3-none-any.whl", hash = "sha256:885daf8261818767d8f7cbd79f9d4482d118f024b6586ef6e67980236a27bfa3"},
+    {file = "aiocontextvars-0.2.2.tar.gz", hash = "sha256:f027372dc48641f683c559f247bd84962becaacdc9ba711d583c3871fb5652aa"},
+]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
@@ -714,6 +760,9 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+contextvars = [
+    {file = "contextvars-2.4.tar.gz", hash = "sha256:f38c908aaa59c14335eeea12abea5f443646216c4e29380d7bf34d2018e2c39e"},
+]
 coverage = [
     {file = "coverage-5.3.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:fabeeb121735d47d8eab8671b6b031ce08514c86b7ad8f7d5490a7b6dcd6267d"},
     {file = "coverage-5.3.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:7e4d159021c2029b958b2363abec4a11db0ce8cd43abb0d9ce44284cb97217e7"},
@@ -765,6 +814,10 @@ coverage = [
     {file = "coverage-5.3.1-pp37-none-any.whl", hash = "sha256:c89b558f8a9a5a6f2cfc923c304d49f0ce629c3bd85cb442ca258ec20366394c"},
     {file = "coverage-5.3.1.tar.gz", hash = "sha256:38f16b1317b8dd82df67ed5daa5f5e7c959e46579840d77a67a4ceb9cef0a50b"},
 ]
+dataclasses = [
+    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
+    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
+]
 fastapi = [
     {file = "fastapi-0.63.0-py3-none-any.whl", hash = "sha256:98d8ea9591d8512fdadf255d2a8fa56515cdd8624dca4af369da73727409508e"},
     {file = "fastapi-0.63.0.tar.gz", hash = "sha256:63c4592f5ef3edf30afa9a44fa7c6b7ccb20e0d3f68cd9eba07b44d552058dcb"},
@@ -784,6 +837,20 @@ httpx = [
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
+]
+immutables = [
+    {file = "immutables-0.14-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:860666fab142401a5535bf65cbd607b46bc5ed25b9d1eb053ca8ed9a1a1a80d6"},
+    {file = "immutables-0.14-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:ce01788878827c3f0331c254a4ad8d9721489a5e65cc43e19c80040b46e0d297"},
+    {file = "immutables-0.14-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:8797eed4042f4626b0bc04d9cf134208918eb0c937a8193a2c66df5041e62d2e"},
+    {file = "immutables-0.14-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:33ce2f977da7b5e0dddd93744862404bdb316ffe5853ec853e53141508fa2e6a"},
+    {file = "immutables-0.14-cp36-cp36m-win_amd64.whl", hash = "sha256:6c8eace4d98988c72bcb37c05e79aae756832738305ae9497670482a82db08bc"},
+    {file = "immutables-0.14-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:ab6c18b7b2b2abc83e0edc57b0a38bf0915b271582a1eb8c7bed1c20398f8040"},
+    {file = "immutables-0.14-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:c099212fd6504513a50e7369fe281007c820cf9d7bb22a336486c63d77d6f0b2"},
+    {file = "immutables-0.14-cp37-cp37m-win_amd64.whl", hash = "sha256:714aedbdeba4439d91cb5e5735cb10631fc47a7a69ea9cc8ecbac90322d50a4a"},
+    {file = "immutables-0.14-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:1c11050c49e193a1ec9dda1747285333f6ba6a30bbeb2929000b9b1192097ec0"},
+    {file = "immutables-0.14-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:c453e12b95e1d6bb4909e8743f88b7f5c0c97b86a8bc0d73507091cb644e3c1e"},
+    {file = "immutables-0.14-cp38-cp38-win_amd64.whl", hash = "sha256:ef9da20ec0f1c5853b5c8f8e3d9e1e15b8d98c259de4b7515d789a606af8745e"},
+    {file = "immutables-0.14.tar.gz", hash = "sha256:a0a1cc238b678455145bae291d8426f732f5255537ed6a5b7645949704c70a78"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-3.3.0-py3-none-any.whl", hash = "sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450"},
@@ -969,10 +1036,6 @@ pytest-cov = [
     {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},
     {file = "pytest_cov-2.10.1-py2.py3-none-any.whl", hash = "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191"},
 ]
-pytest-httpx = [
-    {file = "pytest_httpx-0.10.1-py3-none-any.whl", hash = "sha256:d32e8f6fb7e028f0313f5f5a2d463c8673eb43fd11a9bfe8527299717a7764c4"},
-    {file = "pytest_httpx-0.10.1.tar.gz", hash = "sha256:0a7c56e559b23efbf857054cd74de60a7c540694a162423f89c70da6ad358d8e"},
-]
 regex = [
     {file = "regex-2020.11.13-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85"},
     {file = "regex-2020.11.13-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a63f1a07932c9686d2d416fb295ec2c01ab246e89b4d58e5fa468089cab44b70"},
@@ -1019,6 +1082,10 @@ regex = [
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
     {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
+]
+respx = [
+    {file = "respx-0.16.3-py2.py3-none-any.whl", hash = "sha256:2db35e4af6bf25f58435457da7a0df52b34b8b3c2ea584d8a8cce27a7b00a614"},
+    {file = "respx-0.16.3.tar.gz", hash = "sha256:3f4781a7fc02d6162f63f33c1481b31d83c0b8c54e98a077932a4197182a7312"},
 ]
 rfc3986 = [
     {file = "rfc3986-1.4.0-py2.py3-none-any.whl", hash = "sha256:af9147e9aceda37c91a05f4deb128d4b4b49d6b199775fd2d2927768abdc8f50"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Mustafa Mohamed <ms7mohamed@gmail.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.6"
 loguru = "^0.5.3"
 fastapi = "^0.63.0"
 pydantic = "^1.7.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ pylint = "^2.6.0"
 pyperclip = "^1.8.1"
 taskipy = "^1.6.0"
 pytest-cov = "^2.10.1"
-pytest-httpx = "^0.10.1"
+respx = "^0.16.3"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_network_calls.py
+++ b/tests/test_network_calls.py
@@ -1,3 +1,4 @@
+from httpx import Response
 from dispike.models.incoming import IncomingApplicationCommand
 from pytest_httpx import HTTPXMock
 from dispike import Dispike
@@ -8,6 +9,8 @@ import pytest
 from dispike.errors.network import DiscordAPIError
 from nacl.encoding import HexEncoder
 from nacl.signing import SigningKey
+
+import respx
 
 
 @pytest.fixture
@@ -22,33 +25,32 @@ def dispike_object():
     )
 
 
-def test_get_commands_globally_call_successful(
-    dispike_object: Dispike, httpx_mock: HTTPXMock
-):
-    httpx_mock.add_response(
-        status_code=200,
-        url=f"https://discord.com/api/v8/applications/APPID/commands",
-        json=[
-            {
-                "id": "1234",
-                "application_id": "7890",
-                "name": "mccoolbotv1",
-                "description": "McCoolbot is the coolest bot around.",
-                "options": [
-                    {"type": 6, "name": "wave", "description": "wave at a person"}
-                ],
-            },
-            {
-                "id": "3344",
-                "application_id": "7890",
-                "name": "mccoolbotv2",
-                "description": "send a message",
-                "options": [
-                    {"type": 3, "name": "message", "description": "send a message"}
-                ],
-            },
-        ],
-        method="GET",
+@respx.mock
+def test_get_commands_globally_call_successful(dispike_object: Dispike):
+    respx.get(f"https://discord.com/api/v8/applications/APPID/commands").mock(
+        return_value=Response(
+            200,
+            json=[
+                {
+                    "id": "1234",
+                    "application_id": "7890",
+                    "name": "mccoolbotv1",
+                    "description": "McCoolbot is the coolest bot around.",
+                    "options": [
+                        {"type": 6, "name": "wave", "description": "wave at a person"}
+                    ],
+                },
+                {
+                    "id": "3344",
+                    "application_id": "7890",
+                    "name": "mccoolbotv2",
+                    "description": "send a message",
+                    "options": [
+                        {"type": 3, "name": "message", "description": "send a message"}
+                    ],
+                },
+            ],
+        )
     )
 
     _get_commands = dispike_object.get_commands()
@@ -58,99 +60,97 @@ def test_get_commands_globally_call_successful(
     assert len(_get_commands) == 2
 
 
-def test_get_commands_globally_call_fail(
-    dispike_object: Dispike, httpx_mock: HTTPXMock
-):
-    httpx_mock.add_response(
-        status_code=404,
-        url=f"https://discord.com/api/v8/applications/APPID/commands",
-        json=[
-            {
-                "id": "1234",
-                "application_id": "7890",
-                "name": "mccoolbotv1",
-                "description": "McCoolbot is the coolest bot around.",
-                "options": [
-                    {"type": 6, "name": "wave", "description": "wave at a person"}
-                ],
-            },
-            {
-                "id": "3344",
-                "application_id": "7890",
-                "name": "mccoolbotv2",
-                "description": "send a message",
-                "options": [
-                    {"type": 3, "name": "message", "description": "send a message"}
-                ],
-            },
-        ],
-        method="GET",
+@respx.mock
+def test_get_commands_globally_call_fail(dispike_object: Dispike):
+    respx.get("https://discord.com/api/v8/applications/APPID/commands").mock(
+        return_value=Response(
+            500,
+            json=[
+                {
+                    "id": "1234",
+                    "application_id": "7890",
+                    "name": "mccoolbotv1",
+                    "description": "McCoolbot is the coolest bot around.",
+                    "options": [
+                        {"type": 6, "name": "wave", "description": "wave at a person"}
+                    ],
+                },
+                {
+                    "id": "3344",
+                    "application_id": "7890",
+                    "name": "mccoolbotv2",
+                    "description": "send a message",
+                    "options": [
+                        {"type": 3, "name": "message", "description": "send a message"}
+                    ],
+                },
+            ],
+        )
     )
 
     with pytest.raises(DiscordAPIError):
         _get_commands = dispike_object.get_commands()
 
 
-def test_get_commands_globally_call_invalid_incoming(
-    dispike_object: Dispike, httpx_mock: HTTPXMock
-):
-    httpx_mock.add_response(
-        status_code=200,
-        url=f"https://discord.com/api/v8/applications/APPID/commands",
-        json=[
-            {
-                "id": "1234",
-                "application_id": "7890",
-                "name": "mccoolbotv1",
-                "options": [
-                    {"type": 6, "name": "wave", "description": "wave at a person"}
-                ],
-            },
-            {
-                "id": "3344",
-                "application_id": "7890",
-                "description": "send a message",
-                "options": [
-                    {"type": 3, "name": "message", "description": "send a message"}
-                ],
-            },
-        ],
-        method="GET",
+@respx.mock
+def test_get_commands_globally_call_invalid_incoming(dispike_object: Dispike):
+    respx.get(f"https://discord.com/api/v8/applications/APPID/commands").mock(
+        return_value=Response(
+            200,
+            json=[
+                {
+                    "id": "1234",
+                    "application_id": "7890",
+                    "name": "mccoolbotv1",
+                    "options": [
+                        {"type": 6, "name": "wave", "description": "wave at a person"}
+                    ],
+                },
+                {
+                    "id": "3344",
+                    "application_id": "7890",
+                    "description": "send a message",
+                    "options": [
+                        {"type": 3, "name": "message", "description": "send a message"}
+                    ],
+                },
+            ],
+        )
     )
-
     with pytest.raises(ValidationError):
         _get_commands = dispike_object.get_commands()
 
 
-def test_get_commands_guild_only_call_successful(
-    dispike_object: Dispike, httpx_mock: HTTPXMock
-):
-    httpx_mock.add_response(
-        status_code=200,
-        url=f"https://discord.com/api/v8/applications/APPID/guilds/EXAMPLE_GUILD/commands",
-        json=[
-            {
-                "id": "1234",
-                "application_id": "7890",
-                "name": "mccoolbotv1",
-                "description": "McCoolbot is the coolest bot around.",
-                "options": [
-                    {"type": 6, "name": "wave", "description": "wave at a person"}
-                ],
-            },
-            {
-                "id": "3344",
-                "application_id": "7890",
-                "name": "mccoolbotv2",
-                "description": "send a message",
-                "options": [
-                    {"type": 3, "name": "message", "description": "send a message"}
-                ],
-            },
-        ],
-        method="GET",
-    )
+@respx.mock
+def test_get_commands_guild_only_call_successful(dispike_object: Dispike):
 
+    respx.get(
+        "https://discord.com/api/v8/applications/APPID/guilds/EXAMPLE_GUILD/commands"
+    ).mock(
+        return_value=Response(
+            200,
+            json=[
+                {
+                    "id": "1234",
+                    "application_id": "7890",
+                    "name": "mccoolbotv1",
+                    "description": "McCoolbot is the coolest bot around.",
+                    "options": [
+                        {"type": 6, "name": "wave", "description": "wave at a person"}
+                    ],
+                },
+                {
+                    "id": "3344",
+                    "application_id": "7890",
+                    "name": "mccoolbotv2",
+                    "description": "send a message",
+                    "options": [
+                        {"type": 3, "name": "message", "description": "send a message"}
+                    ],
+                },
+            ],
+        )
+    )
     _get_commands = dispike_object.get_commands(
         guild_only=True, guild_id_passed="EXAMPLE_GUILD"
     )
@@ -160,68 +160,69 @@ def test_get_commands_guild_only_call_successful(
     assert len(_get_commands) == 2
 
 
-def test_get_commands_guild_only_call_fail(
-    dispike_object: Dispike, httpx_mock: HTTPXMock
-):
-    httpx_mock.add_response(
-        status_code=404,
-        url=f"https://discord.com/api/v8/applications/APPID/guilds/EXAMPLE_GUILD/commands",
-        json=[
-            {
-                "id": "1234",
-                "application_id": "7890",
-                "name": "mccoolbotv1",
-                "description": "McCoolbot is the coolest bot around.",
-                "options": [
-                    {"type": 6, "name": "wave", "description": "wave at a person"}
-                ],
-            },
-            {
-                "id": "3344",
-                "application_id": "7890",
-                "name": "mccoolbotv2",
-                "description": "send a message",
-                "options": [
-                    {"type": 3, "name": "message", "description": "send a message"}
-                ],
-            },
-        ],
-        method="GET",
+@respx.mock
+def test_get_commands_guild_only_call_fail(dispike_object: Dispike):
+    respx.get(
+        "https://discord.com/api/v8/applications/APPID/guilds/EXAMPLE_GUILD/commands"
+    ).mock(
+        return_value=Response(
+            404,
+            json=[
+                {
+                    "id": "1234",
+                    "application_id": "7890",
+                    "name": "mccoolbotv1",
+                    "description": "McCoolbot is the coolest bot around.",
+                    "options": [
+                        {"type": 6, "name": "wave", "description": "wave at a person"}
+                    ],
+                },
+                {
+                    "id": "3344",
+                    "application_id": "7890",
+                    "name": "mccoolbotv2",
+                    "description": "send a message",
+                    "options": [
+                        {"type": 3, "name": "message", "description": "send a message"}
+                    ],
+                },
+            ],
+        )
     )
-
     with pytest.raises(DiscordAPIError):
         _get_commands = dispike_object.get_commands(
             guild_only=True, guild_id_passed="EXAMPLE_GUILD"
         )
 
 
-def test_get_commands_guild_only_call_invalid_incoming(
-    dispike_object: Dispike, httpx_mock: HTTPXMock
-):
-    httpx_mock.add_response(
-        status_code=200,
-        url=f"https://discord.com/api/v8/applications/APPID/guilds/EXAMPLE_GUILD/commands",
-        json=[
-            {
-                "id": "1234",
-                "application_id": "7890",
-                "name": "mccoolbotv1",
-                "options": [
-                    {"type": 6, "name": "wave", "description": "wave at a person"}
-                ],
-            },
-            {
-                "id": "3344",
-                "application_id": "7890",
-                "description": "send a message",
-                "options": [
-                    {"type": 3, "name": "message", "description": "send a message"}
-                ],
-            },
-        ],
-        method="GET",
-    )
+@respx.mock
+def test_get_commands_guild_only_call_invalid_incoming(dispike_object: Dispike):
 
+    respx.get(
+        "https://discord.com/api/v8/applications/APPID/guilds/EXAMPLE_GUILD/commands"
+    ).mock(
+        return_value=Response(
+            200,
+            json=[
+                {
+                    "id": "1234",
+                    "application_id": "7890",
+                    "name": "mccoolbotv1",
+                    "options": [
+                        {"type": 6, "name": "wave", "description": "wave at a person"}
+                    ],
+                },
+                {
+                    "id": "3344",
+                    "application_id": "7890",
+                    "description": "send a message",
+                    "options": [
+                        {"type": 3, "name": "message", "description": "send a message"}
+                    ],
+                },
+            ],
+        )
+    )
     with pytest.raises(ValidationError):
         _get_commands = dispike_object.get_commands(
             guild_only=True, guild_id_passed="EXAMPLE_GUILD"

--- a/tests/test_network_calls.py
+++ b/tests/test_network_calls.py
@@ -1,6 +1,5 @@
 from httpx import Response
 from dispike.models.incoming import IncomingApplicationCommand
-from pytest_httpx import HTTPXMock
 from dispike import Dispike
 
 from pydantic import ValidationError

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,5 +1,4 @@
-import httpx
-from pytest_httpx import HTTPXMock
+from httpx import Response
 from dispike.register.models import (
     DiscordCommand,
     CommandOption,
@@ -8,14 +7,14 @@ from dispike.register.models import (
 )
 import pytest
 from dispike.errors.network import DiscordAPIError
+import respx
 
 
-def test_register_command_globally_successful(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
-        status_code=200,
-        url=f"https://discord.com/api/v8/applications/EXAMPLE_APP_ID/commands",
+@respx.mock
+def test_register_command_globally_successful():
+    respx.post("https://discord.com/api/v8/applications/EXAMPLE_APP_ID/commands").mock(
+        return_value=Response(200)
     )
-
     from dispike.register.registrator import RegisterCommands
 
     target_item = RegisterCommands(
@@ -36,11 +35,10 @@ def test_register_command_globally_successful(httpx_mock: HTTPXMock):
     assert target_item.register(command_to_be_created) == True
 
 
-def test_register_command_globally_unsuccessful(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
-        status_code=404,
-        url=f"https://discord.com/api/v8/applications/EXAMPLE_APP_ID/commands",
-        method="POST",
+@respx.mock
+def test_register_command_globally_unsuccessful():
+    respx.post("https://discord.com/api/v8/applications/EXAMPLE_APP_ID/commands").mock(
+        return_value=Response(404)
     )
 
     from dispike.register.registrator import RegisterCommands
@@ -64,12 +62,12 @@ def test_register_command_globally_unsuccessful(httpx_mock: HTTPXMock):
         target_item.register(command_to_be_created)
 
 
-def test_register_command_guild_only_successful(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
-        status_code=200,
-        url=f"https://discord.com/api/v8/applications/EXAMPLE_APP_ID/guilds/EXAMPLE_GUILD/commands",
-        method="POST",
-    )
+@respx.mock
+def test_register_command_guild_only_successful():
+
+    respx.post(
+        "https://discord.com/api/v8/applications/EXAMPLE_APP_ID/guilds/EXAMPLE_GUILD/commands"
+    ).mock(return_value=Response(200))
 
     from dispike.register.registrator import RegisterCommands
 
@@ -96,12 +94,10 @@ def test_register_command_guild_only_successful(httpx_mock: HTTPXMock):
     )
 
 
-def test_register_command_guild_only_unsuccessful(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
-        status_code=404,
-        url=f"https://discord.com/api/v8/applications/EXAMPLE_APP_ID/guilds/EXAMPLE_GUILD/commands",
-        method="POST",
-    )
+def test_register_command_guild_only_unsuccessful():
+    respx.post(
+        "https://discord.com/api/v8/applications/EXAMPLE_APP_ID/guilds/EXAMPLE_GUILD/commands"
+    ).mock(return_value=Response(500))
 
     from dispike.register.registrator import RegisterCommands
 


### PR DESCRIPTION
- Added support for testing on python versions 3.6 - 3.9.
- Updated dependencies for testing
- Add automated workflow for publishing to PyPi based on release tagging.
- Removed pylint testing from workflows due to upstream issue with type hinting. (Will probably just bring it back but skip it for 3.9)