### PR TITLE
v0.5.5

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = dispike/helper/*

--- a/.github/workflows/run_coverage.yaml
+++ b/.github/workflows/run_coverage.yaml
@@ -35,7 +35,7 @@ jobs:
           poetry install
       - name: Pytest Code Cov
         run: |
-          poetry run pytest --cov=dispike tests/ --cov-report=xml
+          poetry run pytest --cov=dispike --cov-config=.coveragerc tests/
       - uses: codecov/codecov-action@v1.1.1
         with:
           fail_ci_if_error: true

--- a/.github/workflows/run_coverage.yaml
+++ b/.github/workflows/run_coverage.yaml
@@ -35,7 +35,7 @@ jobs:
           poetry install
       - name: Pytest Code Cov
         run: |
-          poetry run pytest --cov=dispike --cov-config=.coveragerc tests/
+          poetry run pytest --cov=dispike --cov-config=.coveragerc --cov-report=xml tests/
       - uses: codecov/codecov-action@v1.1.1
         with:
           fail_ci_if_error: true

--- a/dispike/__init__.py
+++ b/dispike/__init__.py
@@ -1,3 +1,8 @@
-__version__ = "0.1.0"
+from importlib_metadata import version
+
+try:
+    __version__ = version(__package__)
+except Exception:
+    __version__ = "unknown"
 
 from .main import Dispike

--- a/dispike/__init__.py
+++ b/dispike/__init__.py
@@ -1,4 +1,13 @@
-from importlib_metadata import version
+try:
+    from importlib_metadata import version
+except Exception:
+    try:
+        from importlib.metadata import version
+    except Exception:
+
+        def version():
+            return "unknown"
+
 
 try:
     __version__ = version(__package__)

--- a/dispike/eventer.py
+++ b/dispike/eventer.py
@@ -28,6 +28,9 @@ class EventHandler(object):
     def check_event_exists(self, event):
         return event in self.callbacks
 
+    def view_event_function_return_type(self, event):
+        return typing.get_type_hints(self.callbacks[event])
+
     async def emit(self, event, *args, **kwargs):
         if event not in self.callbacks:
             raise TypeError(f"event {event} does not have a corresponding handler.")

--- a/dispike/response.py
+++ b/dispike/response.py
@@ -85,16 +85,31 @@ class DiscordResponse(object):
 
 
 class NotReadyResponse(object):
+    """This is just a representation for a response that is not ready.
+    You probably want to use this if you are not ready to immediately return
+    a response to an incoming interaction
+
+    You have access to the original arugmnents that arrived with the interaction by accessing
+    the attribute ``.args``, this returns a dict of kwargs.
+
+    Lower-level access is available by accessing ``._interaction_context``.
+
+    Attributes:
+        - sync_send_callback
+        - async_send_callback
+        - args
+
+
+    """
+
     def __init__(
         self, bot: "Dispike", interaction_context: "IncomingDiscordInteraction"
     ):
-        """This is just a representation for a response that is not ready.
-        You probably want to use this if you are not ready to immediately return
-        a response to an incoming interaction
+        """Incoming context to have a response later.
 
         Args:
-            bot (Dispike): Bot initalizated
-            interaction_context (IncomingDiscordInteraction): Incoming recieved interaction context
+            bot (Dispike): Incoming bot object
+            interaction_context (IncomingDiscordInteraction): incoming discord interaction
         """
         self._application_id = bot._application_id
         self._interaction_id = interaction_context.id
@@ -105,7 +120,20 @@ class NotReadyResponse(object):
         else:
             self.args = {}
 
+        self._interaction_context = interaction_context
+
     def sync_send_callback(self, ready_response: DiscordResponse):
+        """Send a callback synchronously
+
+        Args:
+            ready_response (DiscordResponse): The DiscordResponse that has been created.
+
+        Raises:
+            DiscordAPIError: Any issues that may arrive
+
+        Returns:
+            True: if everything works out
+        """
         try:
             send_callback = httpx.post(
                 f"https://discord.com/api/v8/interactions/{self._interaction_id}/{self._interaction_token}/callback",
@@ -118,6 +146,17 @@ class NotReadyResponse(object):
             raise
 
     async def async_send_callback(self, ready_response: DiscordResponse):
+        """Send a callback asynchronously
+
+        Args:
+            ready_response (DiscordResponse): The DiscordResponse that has been created.
+
+        Raises:
+            DiscordAPIError: Any issues that may arrive
+
+        Returns:
+            True: if everything works out
+        """
         try:
             send_callback = await httpx.AsyncClient().post(
                 f"https://discord.com/api/v8/interactions/{self._interaction_id}/{self._interaction_token}/callback",

--- a/dispike/server.py
+++ b/dispike/server.py
@@ -3,6 +3,7 @@ from loguru import logger
 from .middlewares.verification import DiscordVerificationMiddleware
 from .models.incoming import IncomingDiscordInteraction
 from .eventer import EventHandler
+from .response import DiscordResponse, NotReadyResponse
 import json
 import typing
 
@@ -33,4 +34,14 @@ async def handle_interactions(request: Request) -> Response:
 
     arguments["ctx"] = _parse_to_object
 
-    return await interaction.emit(_parse_to_object.data.name, **arguments)
+    interaction_data = await interaction.emit(_parse_to_object.data.name, **arguments)
+
+    if isinstance(interaction_data, DiscordResponse):
+        interaction_data: DiscordResponse
+        return interaction_data.response
+
+    if isinstance(interaction_data, dict):
+        return interaction_data
+
+    if isinstance(interaction_data, NotReadyResponse):
+        return None

--- a/dispike/server.py
+++ b/dispike/server.py
@@ -6,9 +6,13 @@ from .eventer import EventHandler
 from .response import DiscordResponse, NotReadyResponse
 import json
 import typing
+from .helper.backport.cache import cache
 
 router = APIRouter()
 interaction = EventHandler()
+
+
+_RAISE_FOR_TESTING = False
 
 
 @router.post("/interactions")
@@ -34,8 +38,30 @@ async def handle_interactions(request: Request) -> Response:
 
     arguments["ctx"] = _parse_to_object
 
-    interaction_data = await interaction.emit(_parse_to_object.data.name, **arguments)
+    # Check the type hint for the return type, fallback for checking the type if no hints are provided
+    try:
+        _type_hinted_request = interaction.view_event_function_return_type(
+            _parse_to_object.data.name
+        )
+        _type_hinted_returned_value = _type_hinted_request["return"]
+        if _type_hinted_returned_value == DiscordResponse:
+            _get_res = await interaction.emit(_parse_to_object.data.name, **arguments)
+            return _get_res.response
+        elif _type_hinted_returned_value == NotReadyResponse:
+            return None
+        elif _type_hinted_returned_value == dict:
+            return await interaction.emit(_parse_to_object.data.name, **arguments)
+    except KeyError:
+        logger.error(
+            "unable to find return value for type hint.. resorting to guessing.."
+        )
+        if _RAISE_FOR_TESTING == True:
+            raise AssertionError("No hinting!")
+    except Exception:
+        logger.exception("unhandled exception for returning hinted value")
+        raise
 
+    interaction_data = await interaction.emit(_parse_to_object.data.name, **arguments)
     if isinstance(interaction_data, DiscordResponse):
         interaction_data: DiscordResponse
         return interaction_data.response

--- a/dispike/server.py
+++ b/dispike/server.py
@@ -6,7 +6,6 @@ from .eventer import EventHandler
 from .response import DiscordResponse, NotReadyResponse
 import json
 import typing
-from .helper.backport.cache import cache
 
 router = APIRouter()
 interaction = EventHandler()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dispike"
-version = "0.4.5-alpha.0"
+version = "0.5.0-alpha.0"
 description = "library for interacting with discord slash commands via an independently hosted server. Powered by FastAPI"
 authors = ["Mustafa Mohamed <ms7mohamed@gmail.com>"]
 repository = "https://github.com/ms7m/dispike"

--- a/tests/test_dispike.py
+++ b/tests/test_dispike.py
@@ -59,7 +59,9 @@ def test_valid_registrator_object(dispike_object: Dispike):
 def test_valid_event_handler_object(dispike_object: Dispike):
     from dispike.eventer import EventHandler
 
-    assert isinstance(dispike_object.interaction, EventHandler) == True
+    assert isinstance(dispike_object.interaction, EventHandler) == True, type(
+        dispike_object.interaction
+    )
 
 
 def test_valid_shared_client(dispike_object: Dispike):

--- a/tests/test_dispike.py
+++ b/tests/test_dispike.py
@@ -4,10 +4,6 @@ from dispike import Dispike
 import pytest
 
 
-def test_version():
-    assert __version__ == "0.1.0"
-
-
 def test_initalization():
     from nacl.encoding import HexEncoder
     from nacl.signing import SigningKey

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,7 +1,21 @@
-from dispike.response import DiscordResponse
+from dispike.errors.network import DiscordAPIError
+from dispike.models.incoming import IncomingDiscordInteraction
+from dispike.response import DiscordResponse, NotReadyResponse
 from dispike.helper.embed import Embed
-
+from .test_dispike import dispike_object
+import inspect
 import pytest
+import typing
+import respx
+from httpx import Response
+
+if typing.TYPE_CHECKING:
+    from dispike import Dispike
+
+
+@pytest.fixture
+def sample_discord_response():
+    return DiscordResponse(content="test")
 
 
 def test_string_response():
@@ -49,3 +63,283 @@ def test_invalid_content():
 
     with pytest.raises(TypeError):
         _created_content = DiscordResponse(content="Test", tts="invalid")
+
+
+@pytest.mark.asyncio
+def test_not_ready_response(dispike_object: "Dispike"):
+    data = {
+        "channel_id": "123123",
+        "data": {
+            "id": "12312312",
+            "name": "sendmessage",
+            "options": [{"name": "message", "value": "test"}],
+        },
+        "guild_id": "123123",
+        "id": "123123123132",
+        "member": {
+            "deaf": False,
+            "is_pending": False,
+            "joined_at": "2019-05-12T18:36:16.878000+00:00",
+            "mute": False,
+            "nick": None,
+            "pending": False,
+            "permissions": "2147483647",
+            "premium_since": None,
+            "roles": [
+                "123123",
+                "123123",
+                "1231233",
+                "1231233133",
+                "12412412414",
+            ],
+            "user": {
+                "avatar": "b723979992a56",
+                "discriminator": "3333",
+                "id": "234234213122123",
+                "public_flags": 768,
+                "username": "exo",
+            },
+        },
+        "token": "Null",
+        "type": 2,
+        "version": 1,
+    }
+
+    sample_interaction = IncomingDiscordInteraction(**data)
+    _created_content = NotReadyResponse(
+        bot=dispike_object, interaction_context=sample_interaction
+    )
+
+    assert _created_content._application_id == dispike_object._application_id
+    assert _created_content._interaction_id == 123123123132
+    assert _created_content._interaction_token == "Null"
+    assert _created_content.args == {"message": "test"}
+
+    assert (
+        inspect.iscoroutinefunction(_created_content.async_send_callback) == True
+    ), type(_created_content.async_send_callback)
+    assert inspect.ismethod(_created_content.sync_send_callback) == True, type(
+        _created_content.sync_send_callback
+    )
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_send_callback_for_not_ready(
+    dispike_object: "Dispike", sample_discord_response
+):
+    data = {
+        "channel_id": "123123",
+        "data": {
+            "id": "12312312",
+            "name": "sendmessage",
+            "options": [{"name": "message", "value": "test"}],
+        },
+        "guild_id": "123123",
+        "id": "123123123132",
+        "member": {
+            "deaf": False,
+            "is_pending": False,
+            "joined_at": "2019-05-12T18:36:16.878000+00:00",
+            "mute": False,
+            "nick": None,
+            "pending": False,
+            "permissions": "2147483647",
+            "premium_since": None,
+            "roles": [
+                "123123",
+                "123123",
+                "1231233",
+                "1231233133",
+                "12412412414",
+            ],
+            "user": {
+                "avatar": "b723979992a56",
+                "discriminator": "3333",
+                "id": "234234213122123",
+                "public_flags": 768,
+                "username": "exo",
+            },
+        },
+        "token": "Null",
+        "type": 2,
+        "version": 1,
+    }
+
+    sample_interaction = IncomingDiscordInteraction(**data)
+    _created_content = NotReadyResponse(
+        bot=dispike_object, interaction_context=sample_interaction
+    )
+
+    # TODO: Make a file full of common pytest fixtures for easy access.
+    respx.post(
+        f"https://discord.com/api/v8/interactions/{_created_content._interaction_id}/{_created_content._interaction_token}/callback"
+    ).mock(return_value=Response(status_code=200))
+
+    await _created_content.async_send_callback(sample_discord_response)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_send_callback_for_not_ready_invalid_response(
+    dispike_object: "Dispike", sample_discord_response
+):
+    data = {
+        "channel_id": "123123",
+        "data": {
+            "id": "12312312",
+            "name": "sendmessage",
+            "options": [{"name": "message", "value": "test"}],
+        },
+        "guild_id": "123123",
+        "id": "123123123132",
+        "member": {
+            "deaf": False,
+            "is_pending": False,
+            "joined_at": "2019-05-12T18:36:16.878000+00:00",
+            "mute": False,
+            "nick": None,
+            "pending": False,
+            "permissions": "2147483647",
+            "premium_since": None,
+            "roles": [
+                "123123",
+                "123123",
+                "1231233",
+                "1231233133",
+                "12412412414",
+            ],
+            "user": {
+                "avatar": "b723979992a56",
+                "discriminator": "3333",
+                "id": "234234213122123",
+                "public_flags": 768,
+                "username": "exo",
+            },
+        },
+        "token": "Null",
+        "type": 2,
+        "version": 1,
+    }
+
+    sample_interaction = IncomingDiscordInteraction(**data)
+    _created_content = NotReadyResponse(
+        bot=dispike_object, interaction_context=sample_interaction
+    )
+
+    respx.post(
+        f"https://discord.com/api/v8/interactions/{_created_content._interaction_id}/{_created_content._interaction_token}/callback"
+    ).mock(return_value=Response(status_code=500))
+
+    with pytest.raises(DiscordAPIError):
+        await _created_content.async_send_callback(sample_discord_response)
+
+
+@respx.mock
+def test_sync_send_callback_for_not_ready(
+    dispike_object: "Dispike", sample_discord_response
+):
+    data = {
+        "channel_id": "123123",
+        "data": {
+            "id": "12312312",
+            "name": "sendmessage",
+            "options": [{"name": "message", "value": "test"}],
+        },
+        "guild_id": "123123",
+        "id": "123123123132",
+        "member": {
+            "deaf": False,
+            "is_pending": False,
+            "joined_at": "2019-05-12T18:36:16.878000+00:00",
+            "mute": False,
+            "nick": None,
+            "pending": False,
+            "permissions": "2147483647",
+            "premium_since": None,
+            "roles": [
+                "123123",
+                "123123",
+                "1231233",
+                "1231233133",
+                "12412412414",
+            ],
+            "user": {
+                "avatar": "b723979992a56",
+                "discriminator": "3333",
+                "id": "234234213122123",
+                "public_flags": 768,
+                "username": "exo",
+            },
+        },
+        "token": "Null",
+        "type": 2,
+        "version": 1,
+    }
+
+    sample_interaction = IncomingDiscordInteraction(**data)
+    _created_content = NotReadyResponse(
+        bot=dispike_object, interaction_context=sample_interaction
+    )
+
+    # TODO: Make a file full of common pytest fixtures for easy access.
+    respx.post(
+        f"https://discord.com/api/v8/interactions/{_created_content._interaction_id}/{_created_content._interaction_token}/callback"
+    ).mock(return_value=Response(status_code=200))
+
+    assert _created_content.sync_send_callback(sample_discord_response) == True
+
+
+@respx.mock
+def test_sync_send_callback_for_not_ready_invalid_response(
+    dispike_object: "Dispike", sample_discord_response
+):
+    data = {
+        "channel_id": "123123",
+        "data": {
+            "id": "12312312",
+            "name": "sendmessage",
+            "options": [{"name": "message", "value": "test"}],
+        },
+        "guild_id": "123123",
+        "id": "123123123132",
+        "member": {
+            "deaf": False,
+            "is_pending": False,
+            "joined_at": "2019-05-12T18:36:16.878000+00:00",
+            "mute": False,
+            "nick": None,
+            "pending": False,
+            "permissions": "2147483647",
+            "premium_since": None,
+            "roles": [
+                "123123",
+                "123123",
+                "1231233",
+                "1231233133",
+                "12412412414",
+            ],
+            "user": {
+                "avatar": "b723979992a56",
+                "discriminator": "3333",
+                "id": "234234213122123",
+                "public_flags": 768,
+                "username": "exo",
+            },
+        },
+        "token": "Null",
+        "type": 2,
+        "version": 1,
+    }
+
+    sample_interaction = IncomingDiscordInteraction(**data)
+    _created_content = NotReadyResponse(
+        bot=dispike_object, interaction_context=sample_interaction
+    )
+
+    respx.post(
+        f"https://discord.com/api/v8/interactions/{_created_content._interaction_id}/{_created_content._interaction_token}/callback"
+    ).mock(return_value=Response(status_code=500))
+
+    with pytest.raises(DiscordAPIError):
+        _created_content.sync_send_callback(sample_discord_response)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,10 +1,19 @@
+from dispike.models.incoming import IncomingDiscordInteraction
+from dispike.response import DiscordResponse, NotReadyResponse
 from fastapi.testclient import TestClient
+from dispike.eventer import EventHandler
 from dispike import Dispike
 
 from nacl.encoding import HexEncoder
 from nacl.signing import SigningKey
 import json
+import pytest
+import typing
 
+from loguru import logger
+
+if typing.TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
 
 _generated_signing_key = SigningKey.generate()
 
@@ -28,6 +37,180 @@ client = TestClient(app)
 @app.get("/")
 def test_endpoint():
     return {"status": True}
+
+
+def create_mocked_request(command_name):
+    data = {
+        "channel_id": "123123",
+        "data": {
+            "id": "12312312",
+            "name": command_name,
+            "options": [{"name": "message", "value": "test"}],
+        },
+        "guild_id": "123123",
+        "id": "123123123132",
+        "member": {
+            "deaf": False,
+            "is_pending": False,
+            "joined_at": "2019-05-12T18:36:16.878000+00:00",
+            "mute": False,
+            "nick": None,
+            "pending": False,
+            "permissions": "2147483647",
+            "premium_since": None,
+            "roles": [
+                "123123",
+                "123123",
+                "1231233",
+                "1231233133",
+                "12412412414",
+            ],
+            "user": {
+                "avatar": "b723979992a56",
+                "discriminator": "3333",
+                "id": "234234213122123",
+                "public_flags": 768,
+                "username": "exo",
+            },
+        },
+        "token": "Null",
+        "type": 2,
+        "version": 1,
+    }
+
+    class MockState:
+        _cached_body = IncomingDiscordInteraction(**data).json().encode()
+
+    class MockResponse:
+        state = MockState
+
+    return MockResponse
+
+
+async def hinted_mock_functions(mocked_events: EventHandler):
+    data = {
+        "channel_id": "123123",
+        "data": {
+            "id": "12312312",
+            "name": "sendmessage",
+            "options": [{"name": "message", "value": "test"}],
+        },
+        "guild_id": "123123",
+        "id": "123123123132",
+        "member": {
+            "deaf": False,
+            "is_pending": False,
+            "joined_at": "2019-05-12T18:36:16.878000+00:00",
+            "mute": False,
+            "nick": None,
+            "pending": False,
+            "permissions": "2147483647",
+            "premium_since": None,
+            "roles": [
+                "123123",
+                "123123",
+                "1231233",
+                "1231233133",
+                "12412412414",
+            ],
+            "user": {
+                "avatar": "b723979992a56",
+                "discriminator": "3333",
+                "id": "234234213122123",
+                "public_flags": 768,
+                "username": "exo",
+            },
+        },
+        "token": "Null",
+        "type": 2,
+        "version": 1,
+    }
+
+    @mocked_events.on("hint_return_discord_response")
+    async def return_event_hint(*args, **kwargs) -> DiscordResponse:
+        logger.info("hint_return_discord_response")
+        return DiscordResponse(content="sample")
+
+    @mocked_events.on("hint_return_not_ready_response")
+    async def return_not_ready_hint(*args, **kwargs) -> NotReadyResponse:
+        logger.info("hint_return_not_ready_response")
+        return NotReadyResponse(bot, IncomingDiscordInteraction(**data))
+
+    @mocked_events.on("hint_return_dict")
+    async def return_dict_hint(*args, **kwargs) -> dict:
+        logger.info("hint_return_dict")
+        return {"sample": "sample"}
+
+
+async def no_hinted_mocked_functions(mocked_events: EventHandler):
+    data = {
+        "channel_id": "123123",
+        "data": {
+            "id": "12312312",
+            "name": "sendmessage",
+            "options": [{"name": "message", "value": "test"}],
+        },
+        "guild_id": "123123",
+        "id": "123123123132",
+        "member": {
+            "deaf": False,
+            "is_pending": False,
+            "joined_at": "2019-05-12T18:36:16.878000+00:00",
+            "mute": False,
+            "nick": None,
+            "pending": False,
+            "permissions": "2147483647",
+            "premium_since": None,
+            "roles": [
+                "123123",
+                "123123",
+                "1231233",
+                "1231233133",
+                "12412412414",
+            ],
+            "user": {
+                "avatar": "b723979992a56",
+                "discriminator": "3333",
+                "id": "234234213122123",
+                "public_flags": 768,
+                "username": "exo",
+            },
+        },
+        "token": "Null",
+        "type": 2,
+        "version": 1,
+    }
+
+    @mocked_events.on("no_hint_return_discord_response")
+    async def return_event_no_hinting(*args, **kwargs):
+        logger.info("called no_hint_return_discord_response")
+        return DiscordResponse(content="sample")
+
+    @mocked_events.on("no_hint_return_not_ready_response")
+    async def return_event_no_hinting_not_ready_response(*args, **kwargs):
+        logger.info("no_hint_return_not_ready_response")
+        return NotReadyResponse(bot, IncomingDiscordInteraction(**data))
+
+    @mocked_events.on("no_hint_return_dict")
+    async def return_event_no_hinting_dict(*args, **kwargs):
+        logger.info("no_hint_return_dict")
+        return {"sample": "sample"}
+
+
+@pytest.fixture
+@pytest.mark.asyncio
+async def mocked_interaction():
+    mocked_events = EventHandler()
+    await no_hinted_mocked_functions(mocked_events)
+    return mocked_events
+
+
+@pytest.fixture
+@pytest.mark.asyncio
+async def mocked_interactions_with_hints():
+    mocked_events = EventHandler()
+    await hinted_mock_functions(mocked_events)
+    return mocked_events
 
 
 def test_valid_key_request_redirect():
@@ -64,3 +247,114 @@ def test_ack_ping_discord():
         json=_created_message,
     )
     assert response.json() == {"type": 1}
+
+
+@pytest.mark.asyncio
+async def test_proper_response_hints_no_hint_return_discord_response(
+    mocked_interaction, monkeypatch: "MonkeyPatch"
+):
+    # we honestly just need a specific attribute from the response..
+    from dispike import server
+
+    # monkeypatch.setattr("dispike.server", "EventHandler", mocked_interaction)
+    # monkeypatch.setattr("dispike.server", EventHandler, mocked_interaction)
+
+    def return_mocked():
+        return mocked_interaction
+
+    monkeypatch.setattr(server, "interaction", mocked_interaction)
+    _result = await server.handle_interactions(
+        create_mocked_request("no_hint_return_discord_response")
+    )
+    assert type(_result) == dict
+    assert _result["data"]["content"] == "sample"
+
+
+@pytest.mark.asyncio
+async def test_proper_response_hints_no_hint_return_not_ready_response(
+    mocked_interaction, monkeypatch: "MonkeyPatch"
+):
+    # we honestly just need a specific attribute from the response..
+    from dispike import server
+
+    # monkeypatch.setattr("dispike.server", "EventHandler", mocked_interaction)
+    # monkeypatch.setattr("dispike.server", EventHandler, mocked_interaction)
+
+    def return_mocked():
+        return mocked_interaction
+
+    monkeypatch.setattr(server, "interaction", mocked_interaction)
+    _result = await server.handle_interactions(
+        create_mocked_request("no_hint_return_not_ready_response")
+    )
+    assert _result == None
+
+
+@pytest.mark.asyncio
+async def test_proper_response_hints_no_hint_return_dict(
+    mocked_interaction, monkeypatch: "MonkeyPatch"
+):
+    # we honestly just need a specific attribute from the response..
+    from dispike import server
+
+    monkeypatch.setattr(server, "interaction", mocked_interaction)
+    _result = await server.handle_interactions(
+        create_mocked_request("no_hint_return_dict")
+    )
+    assert type(_result) == dict
+    assert _result == {"sample": "sample"}
+
+
+@pytest.mark.asyncio
+async def test_proper_response_hint_discord_response(
+    mocked_interactions_with_hints, monkeypatch: "MonkeyPatch"
+):
+    # we honestly just need a specific attribute from the response..
+    from dispike import server
+
+    monkeypatch.setattr(server, "interaction", mocked_interactions_with_hints)
+    monkeypatch.setattr(server, "_RAISE_FOR_TESTING", True)
+
+    _result = await server.handle_interactions(
+        create_mocked_request("hint_return_discord_response")
+    )
+    assert type(_result) == dict
+    assert _result["data"]["content"] == "sample"
+
+
+@pytest.mark.asyncio
+async def test_proper_response_hints_hint_return_not_ready_response(
+    mocked_interactions_with_hints, monkeypatch: "MonkeyPatch"
+):
+    # we honestly just need a specific attribute from the response..
+    from dispike import server
+
+    # monkeypatch.setattr("dispike.server", "EventHandler", mocked_interaction)
+    # monkeypatch.setattr("dispike.server", EventHandler, mocked_interaction)
+
+    monkeypatch.setattr(server, "interaction", mocked_interactions_with_hints)
+    monkeypatch.setattr(server, "_RAISE_FOR_TESTING", True)
+
+    _result = await server.handle_interactions(
+        create_mocked_request("hint_return_not_ready_response")
+    )
+    assert _result == None
+
+
+@pytest.mark.asyncio
+async def test_proper_response_hints_hint_return_dict(
+    mocked_interactions_with_hints, monkeypatch: "MonkeyPatch"
+):
+    # we honestly just need a specific attribute from the response..
+    from dispike import server
+
+    # monkeypatch.setattr("dispike.server", "EventHandler", mocked_interaction)
+    # monkeypatch.setattr("dispike.server", EventHandler, mocked_interaction)
+
+    monkeypatch.setattr(server, "interaction", mocked_interactions_with_hints)
+    monkeypatch.setattr(server, "_RAISE_FOR_TESTING", True)
+    _result = await server.handle_interactions(
+        create_mocked_request("hint_return_dict")
+    )
+    assert type(_result) == dict
+    assert _result == {"sample": "sample"}


### PR DESCRIPTION
- You can now directly return ``DiscordResponse`` inside your handler. Dispike will either check the function result, or will look at your hint for the function (this is perferred)
- You can now use ``NotReadyResponse``, this response returns nothing to discord when an interaction is called, but saves the token and ID as well as methods ``sync_send_callback`` and ``async_send_callback`` that allow for sending a ``DiscordResponse`` later.


### ⚠️  Warning  ⚠️ 

Autocompletion for creating new models under DiscordCommand, CommandChoice, CommandOption, SubcommandOption, CommandTypes **on VSCode is broken.** (follow discussion here https://github.com/samuelcolvin/pydantic/issues/650, https://github.com/microsoft/python-language-server/issues/1898). PyCharm appears to work using an external plugin.