### PR TITLE
v0.8.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ data.json
 data2.json
 
 keys.json
+dist/*

--- a/dispike/__init__.py
+++ b/dispike/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.8.2-alpha.0"
+__version__ = "0.8.9-alpha.0"
 
 from .main import Dispike

--- a/dispike/main.py
+++ b/dispike/main.py
@@ -22,13 +22,16 @@ class Dispike(object):
     *Powered by FastAPI*
     """
 
-    def __init__(self, client_public_key: str, bot_token: str, application_id: str):
+    def __init__(
+        self, client_public_key: str, bot_token: str, application_id: str, **kwargs
+    ):
         """Initialize Dispike Object
 
         Args:
             client_public_key (str): Discord provided client public key.
             bot_token (str): Discord provided bot token. You must create a bot user to view this!
             application_id (str): Discord provided Client ID
+            custom_context_argument_name (str, optional): Change the name of the context arugment when passing to a function. Set to "ctx".
         """
         self._bot_token = bot_token
         self._application_id = application_id
@@ -40,6 +43,14 @@ class Dispike(object):
             DiscordVerificationMiddleware, client_public_key=client_public_key
         )
         self._internal_application.include_router(router=router)
+        if not kwargs.get("custom_context_argument_name"):
+            router._user_defined_setting_ctx_value = "ctx"
+        else:
+            router._user_defined_setting_ctx_value = kwargs.get(
+                "custom_context_argument_name"
+            )
+
+        self._cache_router = router
 
     def reset_registration(self, new_bot_token=None, new_application_id=None):
         """This method resets the built-in RgeisterCommands.

--- a/dispike/models/discord_types/user.py
+++ b/dispike/models/discord_types/user.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+import typing
 
 try:
     from typing import Literal
@@ -18,6 +19,6 @@ class User(BaseModel):
 
     id: int
     username: str
-    avatar: str
+    avatar: typing.Union[None, str]
     discriminator: str
     public_flags: int

--- a/dispike/server.py
+++ b/dispike/server.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Request, Response, BackgroundTasks
+from fastapi import APIRouter, Request, Response
 from fastapi.responses import PlainTextResponse
 from loguru import logger
 from .middlewares.verification import DiscordVerificationMiddleware
@@ -46,9 +46,9 @@ async def handle_interactions(request: Request) -> Response:
         logger.debug("discarding event not existing.")
         return {"type": 5}
 
-    _event_settings = interaction.return_event_settings(_event_name)
+    # _event_settings = interaction.return_event_settings(_event_name)
 
-    arguments["ctx"] = _parse_to_object
+    arguments[router._user_defined_setting_ctx_value] = _parse_to_object
 
     # Check the type hint for the return type, fallback for checking the type if no hints are provided
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dispike"
-version = "0.8.8-alpha.0"
+version = "0.8.9-alpha.0"
 description = "library for interacting with discord slash commands via an independently hosted server. Powered by FastAPI"
 authors = ["Mustafa Mohamed <ms7mohamed@gmail.com>"]
 repository = "https://github.com/ms7m/dispike"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -335,3 +335,28 @@ async def test_return_type_5_if_no_event_exists(
     _result = await server.handle_interactions(create_mocked_request("invalid"))
     assert type(_result) == dict
     assert _result == {"type": 5}
+
+
+@pytest.mark.asyncio
+async def test_custom_ctx_argument_name():
+    from dispike import Dispike
+
+    d = Dispike(
+        client_public_key=verification_key.decode(),
+        bot_token="NotNeeded",
+        application_id="NotNeeded",
+        custom_context_argument_name="context",
+    )
+    assert d._cache_router._user_defined_setting_ctx_value == "context"
+
+
+@pytest.mark.asyncio
+async def test_default_ctx_argument_name():
+    from dispike import Dispike
+
+    d = Dispike(
+        client_public_key=verification_key.decode(),
+        bot_token="NotNeeded",
+        application_id="NotNeeded",
+    )
+    assert d._cache_router._user_defined_setting_ctx_value == "ctx"


### PR DESCRIPTION
# Fixes

- Fixes #30 (A Discord user without an avatar will raise a Validation Error).


# New

- You can now specifiy the argument name for ``IncomingDiscordInteraction`` when it's passed to your function. (Default is "``ctx``"). You can specifiy it with the  ``custom_context_argument_name`` arugment when initializing the ``Dispike`` object. 

```python

bot = Dispike(..., custom_context_argument_name="discord_context")

@bot.interaction.on("example")
async def example_command_handler(..., discord_context: IncomingDiscordInteraction):
    ...
```
