### PR TITLE
v0.9.6

### DIFF
--- a/dispike/main.py
+++ b/dispike/main.py
@@ -355,12 +355,15 @@ class Dispike(object):
         """
         async with httpx.AsyncClient(
             base_url=f"https://discord.com/api/v8/webhooks/{self._application_id}/{original_context.token}/messages/",
-            headers={"Authorization": f"Bot {self._bot_token}"},
+            headers={
+                "Authorization": f"Bot {self._bot_token}",
+                "Content-Type": "application/json",
+            },
         ) as client:
             try:
                 # TODO: Probably change later to inside the DeferredResponse?
                 new_message._switch_to_followup_message()
-                response = await client.patch("/@original", data=new_message.response)
+                response = await client.patch("/@original", json=new_message.response)
                 response.raise_for_status()
             except httpx.HTTPError:
                 logger.exception(

--- a/dispike/response.py
+++ b/dispike/response.py
@@ -62,11 +62,12 @@ class DiscordResponse(object):
         self._content = content
         self._tts = tts
         self._embeds = [x.to_dict() for x in embeds]
-        if show_user_input == False:
-            logger.warning("show_user_input is longer supported by discord.")
-            self._type_response = 4
-        else:
-            self._type_response = 4
+        if show_user_input == True:
+            logger.warning(
+                "show_user_input is no longer supported by Discord, and deprecated by Dispike. Future versions may remove this parameter."
+            )
+
+        self._type_response = 4
 
         self._is_followup = follow_up_message
         self._is_empherical = empherical

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dispike"
-version = "0.9.5-alpha.0"
+version = "0.9.6-alpha.0"
 description = "library for interacting with discord slash commands via an independently hosted server. Powered by FastAPI"
 authors = ["Mustafa Mohamed <ms7mohamed@gmail.com>"]
 repository = "https://github.com/ms7m/dispike"


### PR DESCRIPTION
# Fixes

- Fix an issue where adding an ``Embed`` to a ``DiscordResponse`` and sending it through deferred messages would return a 400 error from Discord. #42
- Fixes an issue where a warning about deprecated ``show_user_input`` would appear even if you did not set the value to ``True``. #41 